### PR TITLE
Ability to re-load a file from remote

### DIFF
--- a/lib/ftp-remote-edit-plus.js
+++ b/lib/ftp-remote-edit-plus.js
@@ -60,6 +60,7 @@ class FtpRemoteEdit {
       'ftp-remote-edit:new-directory': () => self.newDirectory(),
       'ftp-remote-edit:delete': () => self.delete(),
       'ftp-remote-edit:rename': () => self.rename(),
+      'ftp-remote-edit:reload': () => self.reload(),
       'ftp-remote-edit:copy': () => self.copy(),
       'ftp-remote-edit:cut': () => self.cut(),
       'ftp-remote-edit:paste': () => self.paste(),
@@ -393,6 +394,93 @@ class FtpRemoteEdit {
       }
     }
   }
+
+  // Reload From Remote
+  // This function will attempt to re-load the file from remote
+  // This is particularly useful if you are editing the file on remote
+  // but you want local copy to refresh. Closing and opening is definitely
+  // a way but reload makes it a bit easier.
+  reload() {
+    const self = this;
+    const selected = self.treeView.list.find('.selected');
+
+    if (selected.length === 0) return;
+
+    if (selected) {
+      // We care about files only. The same cam be implemented at the folder level - later
+      if (!selected.view().is('.directory')) {
+        let file = selected.view();
+        if (file) {
+          // get the textEditor object, if the file is open in a pane, we will
+          // get a textEditor object, else null
+          const textEditor = file.getTextEditor(file.getLocalPath(true) + file.name);
+
+          if (self.debug) {
+              console.log("Reload file ", file.getLocalPath(true) + file.name, "textEditor = ", textEditor);
+          }
+
+          if (textEditor) {
+              // We want to reaload, unless user says No
+              let doReload = true;
+
+              // Find if the buffer is modified (i.e. there is a local change)
+              // If there is no change, we can simply proceed with reload
+              // If there is change, warn user that the local changes would
+              // be lost
+              const modified = textEditor.isModified();
+              if (modified) {
+                  doReload = atom.confirm({
+                      message: 'Do you want to Reload from Remote with local changes?',
+                      detailedMessage: `You will lose your local changes if you choose Yes`,
+                      buttons: {
+                          Yes: () => true,
+                          No: () => false,
+                      },
+                  });
+              }
+              if (!doReload) {
+                // User says don't reload - so just go away..
+                if (self.debug) {
+                    console.log("User cancelled reload");
+                }
+                return;
+              }
+
+              // Now that we want to reload, get hold of the window pane.
+              pane = atom.workspace.paneForItem(textEditor);
+              if (pane) {
+                  if (self.debug) {
+                      console.log("Go ahead and destroy the pane ", pane);
+                  }
+                  // We have user's approval to nuke the pane (without having it
+                  // ask for confirmation).
+                  const forceDestroyWithoutConfirmation = true;
+                  pane.destroyItem(textEditor, forceDestroyWithoutConfirmation)
+                  .then((destroyed) => {
+                    if (self.debug) {
+                      console.log("File Closed status = ", destroyed);
+                    }
+                    if (destroyed) {
+                      // Pane has been destroyed - go ahead and open the file again
+                      if (self.debug) {
+                          console.log("file Closed - open it again");
+                      }
+                      file.open();
+                    }
+                  })
+                  .catch(function (err) {
+                      console.log("Error closing file", err);
+                  });
+              } else {
+                  // Not sure if there is a case where the pane would be absent
+                  // Irrespective, opeh the file
+                  file.open();
+              }
+          }
+        }
+      }
+    }
+  };
 
   rename() {
     const self = this;

--- a/lib/ftp-remote-edit-plus.js
+++ b/lib/ftp-remote-edit-plus.js
@@ -466,6 +466,8 @@ class FtpRemoteEdit {
                           console.log("file Closed - open it again");
                       }
                       file.open();
+                    } else {
+                        console.log("error- window pane could not be destroyed..");
                     }
                   })
                   .catch(function (err) {
@@ -473,7 +475,7 @@ class FtpRemoteEdit {
                   });
               } else {
                   // Not sure if there is a case where the pane would be absent
-                  // Irrespective, opeh the file
+                  // Irrespective, open the file
                   file.open();
               }
           }

--- a/lib/ftp-remote-edit-plus.js
+++ b/lib/ftp-remote-edit-plus.js
@@ -420,7 +420,7 @@ class FtpRemoteEdit {
           }
 
           if (textEditor) {
-              // We want to reaload, unless user says No
+              // We want to reload, unless user says No
               let doReload = true;
 
               // Find if the buffer is modified (i.e. there is a local change)
@@ -458,12 +458,12 @@ class FtpRemoteEdit {
                   pane.destroyItem(textEditor, forceDestroyWithoutConfirmation)
                   .then((destroyed) => {
                     if (self.debug) {
-                      console.log("File Closed status = ", destroyed);
+                      console.log("Pane Closed status = ", destroyed);
                     }
                     if (destroyed) {
                       // Pane has been destroyed - go ahead and open the file again
                       if (self.debug) {
-                          console.log("file Closed - open it again");
+                          console.log("pane closed - open the file again");
                       }
                       file.open();
                     } else {

--- a/menus/ftp-remote-edit.json
+++ b/menus/ftp-remote-edit.json
@@ -114,6 +114,10 @@
         "command": "ftp-remote-edit:rename"
       },
       {
+        "label": "Reload From Remote",
+        "command": "ftp-remote-edit:reload"
+      },
+      {
         "label": "Delete",
         "command": "ftp-remote-edit:delete"
       },


### PR DESCRIPTION
This pull request adds an option called "Reload From Remote" to the file context menu.
If the buffer is open, it will be closed (appropriate warning displayed if there are local changes).
Once close, the file will be opened again

Test-cases:

Test-case-1: Open remote tree view (but file is not yet opened), right click on file and "Reload From Remote"
Expected outcome: Since file is not open, nothing happens (i.e this will not result in opening the file)
Result: Pass

Test-case-2a: Open a remote file, then, without making any local change - do "Reload From Remote"
Expected outcome: File should reload
Result: Pass

Test-case-2b: Open a remote file, then make a change on remote. Don't make any local change - do "Reload From Remote"
Expected outcome: File should reload and the remote changed content should be visible
Result: Pass

Test-case-4a: Open a remote file, Make a local change - do "Reload From Remote". A dialog box will appear indicating that "you will lose your local changes if you reload from remote". Press No
Expected outcome: Nothing happens, the file is not reloaded the local buffer remains
Result: Pass

Test-case-4b: Open a remote file, Make a local change - do "Reload From Remote". A dialog box will appear indicating that "you will lose your local changes if you reload from remote". Press Yes
Expected outcome: Local buffer is closed (lost) and remote content is loaded.
Result: Pass