### PR TITLE
Add Edit-Folders option to ftp-remote-edit context menu

### DIFF
--- a/menus/ftp-remote-edit.json
+++ b/menus/ftp-remote-edit.json
@@ -164,6 +164,10 @@
       {
         "label": "Edit Servers",
         "command": "ftp-remote-edit:edit-servers"
+      },
+      {
+        "label": "Edit Folders",
+        "command": "ftp-remote-edit:edit-folders"
       }
     ],
 


### PR DESCRIPTION
Ftp-remote edit context menu, where servers/folders are shown (right click) doesn't have edit-folder option. It only has edit-servers.

The only way to access this is via Menu -> packages -> ftp-remote-edit-plus
Able to get to edit-folders via context menu is very handy.